### PR TITLE
Portability features for Darwin (MacOSX) platform and Intel/GNU/PGI compilers

### DIFF
--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -1656,11 +1656,13 @@ if( mod( ny_dom, window(2) ) .NE. 0 ) call error_mesg('test_data_override', &
         "ny_dom is not divisible by window(2)", FATAL)
 
 nwindows = window(1)*window(2)
+#ifndef __APPLE__
 !$ call omp_set_num_threads(nthreads)
 !$ base_cpu = get_cpu_affinity()
 !$OMP PARALLEL
 !$ call set_cpu_affinity( base_cpu + omp_get_thread_num() )
 !$OMP END PARALLEL
+#endif
 
 nx_win = nx_dom/window(1)
 ny_win = ny_dom/window(2)

--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -92,8 +92,8 @@
 #define NF_GET_ATT_REAL nf_get_att_double
 #endif
 
-#if defined __CRAYXT_COMPUTE_LINUX_TARGET || defined __GFORTRAN__
-!Cray XT compilers do not support real*16 computation
+#if defined __CRAYXT_COMPUTE_LINUX_TARGET || defined __PGI
+!Cray XT and PGI compilers do not support real*16 computation
 !also known as 128-bit or quad precision
 #define NO_QUAD_PRECISION
 #endif

--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
+#ifndef __APPLE__
 #define _GNU_SOURCE
 
 #include <stdio.h>
@@ -80,3 +81,4 @@ void set_cpu_affinity( int cpu )
 }
 
 void set_cpu_affinity_(int *cpu) { set_cpu_affinity(*cpu); }	/* Fortran interface */
+#endif

--- a/mpp/include/mpp_gather.h
+++ b/mpp/include/mpp_gather.h
@@ -143,7 +143,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
    type array3D
      MPP_TYPE_, dimension(:,:,:), allocatable :: data
    endtype array3D
-   type(array3d), dimension(size(pelist)) :: temp
+   type(array3d), dimension(:), allocatable :: temp
 
    if (.not.ANY(mpp_pe().eq.pelist(:))) return
 
@@ -178,6 +178,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
 
 ! gather indices into global index on root_pe
    if (is_root_pe) then
+     allocate(temp(1:size(pelist)))
      do i = 1, size(pelist)
 ! root_pe data copy - no send to self
        if (pelist(i).eq.root_pe) then

--- a/mpp/test_mpp_domains.F90
+++ b/mpp/test_mpp_domains.F90
@@ -159,11 +159,13 @@ program test
   end if
   call mpp_domains_set_stack_size(stackmax)
 
+#ifndef __APPLE__
 !$      call omp_set_num_threads(nthreads)
 !$      base_cpu = get_cpu_affinity()
 !$OMP PARALLEL
 !$        call set_cpu_affinity( base_cpu + omp_get_thread_num() )
 !$OMP END PARALLEL
+#endif
 
   if( pe.EQ.mpp_root_pe() )print '(a,9i6)', 'npes, mpes, nx, ny, nz, whalo, ehalo, shalo, nhalo =', &
                            npes, mpes, nx, ny, nz, whalo, ehalo, shalo, nhalo


### PR DESCRIPTION
This PR adds portability features that were accepted by EMC earlier this year into their FV3/fms code.

The following issues are addressed:

- A bug in Intel18 causes the mpp_gather routines to crash when is_root_pe is false. This bug is currently under investigation by the Intel developers. The workaround has also been accepted by GFDL-FMS for future inclusion, but has not been merged yet.

- Reasonably recent GNU compilers (4.6+) do support 64-bit floating point operations via the libquadmath library, however PGI compilers still don't. This is corrected in fms_platform.h

- Darwin MacOSX systems do no longer support the deprecated system calls that are used to fine tune the placement of tasks on processors via get_cpu_affinity and set_cpu_affinity. This code is removed from the FMS build for Darwin MacOSX systems using the __APPLE__ preprocessor directive, and so are the corresponding calls to it.

It should be noted here that FV3/fms contains one additional change that is not included in this PR. This particular change was required in the past to avoid crashes in mpp_domains_define.inc's set_single_overlap routine when the GNU compilers were used. The code inside the routine itself is correct and as such it was assumed that the real cause for the crash was in other parts of the code executed before entering the routine. My preliminary testing shows that this workaround is no longer required, and since I do not want to introduce unnecessary changes to correct code, I propose to start from this PR. If needed, a follow-up PR for the mpp_domains_define.inc change can be issued later.