### PR TITLE
FMS portability updates 11/01/2018

### DIFF
--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -27,22 +27,20 @@
 #include <sys/resource.h>
 #include <sys/syscall.h>
 
+#ifndef __APPLE__
 static pid_t gettid(void)
 {
-#ifdef __APPLE__
-  return syscall(SYS_gettid);
-#else
   return syscall(__NR_gettid);
-#endif
 }
+#endif
 
-#ifndef __APPLE__
 /*
  * Returns this thread's CPU affinity, if bound to a single core,
  * or else -1.
  */
 int get_cpu_affinity(void)
 {
+#ifndef __APPLE__
   cpu_set_t coremask;		/* core affinity mask */
 
   CPU_ZERO(&coremask);
@@ -65,6 +63,7 @@ int get_cpu_affinity(void)
 
   if (last_cpu != -1) {return (first_cpu);}
   return (last_cpu == -1) ? first_cpu : -1;
+#endif
 }
 
 int get_cpu_affinity_(void) { return get_cpu_affinity(); }	/* Fortran interface */
@@ -75,6 +74,7 @@ int get_cpu_affinity_(void) { return get_cpu_affinity(); }	/* Fortran interface 
  */
 void set_cpu_affinity( int cpu )
 {
+#ifndef __APPLE__
   cpu_set_t coremask;		/* core affinity mask */
 
   CPU_ZERO(&coremask);
@@ -82,7 +82,7 @@ void set_cpu_affinity( int cpu )
   if (sched_setaffinity(gettid(),sizeof(cpu_set_t),&coremask) != 0) {
     fprintf(stderr,"Unable to set thread %d affinity. %s\n",gettid(),strerror(errno));
   }
+#endif
 }
 
 void set_cpu_affinity_(int *cpu) { set_cpu_affinity(*cpu); }	/* Fortran interface */
-#endif

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -5234,7 +5234,7 @@ end subroutine check_message_size
     real,    dimension(4*num_contact) :: refineRecv, refineSend
     integer, dimension(4*num_contact) :: rotateSend, rotateRecv, tileSend, tileRecv
     integer                           :: nsend, nrecv, nsend2, nrecv2
-    type(contact_type), dimension(:), allocatable           :: eCont, wCont, sCont, nCont
+    type(contact_type), dimension(domain%ntiles)            :: eCont, wCont, sCont, nCont
     type(overlap_type), dimension(0:size(domain%list(:))-1) :: overlapSend, overlapRecv
     integer                                                 :: unit
 
@@ -5242,10 +5242,6 @@ end subroutine check_message_size
          "routine define_contact_point can only be used to calculate overlapping for cell center.")
 
     ntiles  = domain%ntiles
-    allocate(eCont(1:ntiles))
-    allocate(wCont(1:ntiles))
-    allocate(sCont(1:ntiles))
-    allocate(nCont(1:ntiles))
 
     eCont(:)%ncontact = 0
 
@@ -5815,11 +5811,6 @@ end subroutine check_message_size
        deallocate(nCont(n)%is1, nCont(n)%ie1, nCont(n)%js1, nCont(n)%je1 )
        deallocate(nCont(n)%is2, nCont(n)%ie2, nCont(n)%js2, nCont(n)%je2 )
     end do
-
-    deallocate(eCont)
-    deallocate(wCont)
-    deallocate(sCont)
-    deallocate(nCont)
 
     domain%initialized = .true.
 

--- a/mpp/include/mpp_gather.h
+++ b/mpp/include/mpp_gather.h
@@ -143,7 +143,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
    type array3D
      MPP_TYPE_, dimension(:,:,:), allocatable :: data
    endtype array3D
-   type(array3d), dimension(size(pelist)) :: temp
+   type(array3d), dimension(:), allocatable :: temp
 
    if (.not.ANY(mpp_pe().eq.pelist(:))) return
 
@@ -178,6 +178,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
 
 ! gather indices into global index on root_pe
    if (is_root_pe) then
+     allocate(temp(1:size(pelist)))
      do i = 1, size(pelist)
 ! root_pe data copy - no send to self
        if (pelist(i).eq.root_pe) then
@@ -229,6 +230,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
          deallocate(temp(i)%data)
        endif
      enddo
+     deallocate(temp)
    else
 !    non root_pe's send data to root_pe
      msgsize = (my_ind(2)-my_ind(1)+1) * (my_ind(4)-my_ind(3)+1) * nk

--- a/mpp/include/mpp_read_2Ddecomp.h
+++ b/mpp/include/mpp_read_2Ddecomp.h
@@ -198,7 +198,6 @@
           do i = 1,size(field%axes(:))
              axsiz(i) = field%size(i)
              if( i .EQ. field%time_axis_index )start(i) = tlevel
-
           end do
           if( PRESENT(domain) )then
               call mpp_get_compute_domain( domain, is,  ie,  js,  je, tile_count=tile_count, position=position  )


### PR DESCRIPTION
This PR adds missing/modifies existing/removes no longer needed portability features from the GFS-FMS branch with the goal to minimize the drift from NOAA-GFDL FMS master:

- mpp/include/mpp_gather.h: bugfix/workaround for Intel18 compiler, already in NOAA-GFDL/FMS master and required to run the fv3_stretched_nest tests with Intel18
- mpp/affinity.c: use empty functions to set and get affinity on MacOSX platforms instead of removing functions entirely; this is a modified version of the changes to mpp/affinit.c that was created based on the request by Rusty, currently prepared for merging into NOAA-GFDL/FMS master
- mpp/include/mpp_domains_define.inc: revert workaround previously introduced for gfortran, no longer required; this change removes a workaround that was needed several months back to mitigate a GNU crash when starting up the model; it turns out that this is no longer required, most likely because the crash in that particular file was only a symptom for an issue that had to do with the ESMF version used back then (pre 7.1.0); that workaround never made it into NOAA-GFDL/FMS master

The modified FMS branch was tested with the following NEMSfv3gfs versions:

- with VLAB master branch:
	- NEMSCompsetRun on Theia/Intel (./NEMS/NEMSCompsetRun -f)
	- standard full regression test suite on Theia/Intel (./rt.sh -f)

- with GitHub CCPP branch:
	- bit-for-bit comparison of fv3_control vs fv3_ccpp_control on MacOSX/GNU
	- standard full regression test suite no-CCPP on Theia/Intel (./rt.sh -f)
	- regression test suite no-CCPP (create mode) on Theia/GNU (./rt.sh -l rt_gnu_pgi.conf -c fv3)
	- regression test suite no-CCPP (create mode) on Theia/PGI (./rt.sh -l rt_gnu_pgi.conf -c fv3)
	- regression test suite CCPP reference (create mode) on Theia/Intel (./rt.sh -l rt_ccpp_ref.conf -c fv3)
	- regression test suite CCPP hybrid (compare against CCPP reference) on Theia/Intel (./rt.sh -l rt_ccpp_hybrid.conf -m)