### PR TITLE
Make FMS compile with implicit-none error checking enabled

### DIFF
--- a/block_control/block_control.F90
+++ b/block_control/block_control.F90
@@ -74,7 +74,7 @@ contains
     integer, dimension(nx_block) :: i1, i2
     integer, dimension(ny_block) :: j1, j2
     character(len=256) :: text
-    integer :: i, j, nblks, ii, jj
+    integer :: i, j, nblks, ii, jj, ix
 
     if (message) then
       if ((mod(iec-isc+1,nx_block) .ne. 0) .or. (mod(jec-jsc+1,ny_block) .ne. 0)) then


### PR DESCRIPTION
Compiling FMS with implicit-none error checking enabled currently fails for block_control.F90 for a single variable ix. This PR fixes the issue so that FMS can be compiled with `-fimplicit-none` (GNU) or the equivalent flag for Intel.