### PR TITLE
Fix compiler warning: mpp_io_write.inc(1102): #warning: macro redefined

### DIFF
--- a/mpp/include/mpp_io_write.inc
+++ b/mpp/include/mpp_io_write.inc
@@ -1099,8 +1099,8 @@
 #include <mpp_write_2Ddecomp.h>
 
 #ifdef OVERLOAD_R8
+#undef WRITE_RECORD_
 #define WRITE_RECORD_ write_record_r8
-#undef MPP_WRITE_2DDECOMP_2D_
 #undef MPP_WRITE_2DDECOMP_2D_
 #define MPP_WRITE_2DDECOMP_2D_ mpp_write_2ddecomp_r2d_r8
 #undef MPP_WRITE_2DDECOMP_3D_


### PR DESCRIPTION
mpp_io_write.inc(1102): #warning: macro redefined: WRITE_RECORD_